### PR TITLE
XmlWrite should be able to accept different types than Cow<str>

### DIFF
--- a/strong-xml-derive/src/xml_write.rs
+++ b/strong-xml-derive/src/xml_write.rs
@@ -157,9 +157,9 @@ fn write_flatten_text(tag: &LitStr, name: &Ident, ty: &Type) -> TokenStream {
             write!(&mut writer, concat!("</" , #tag, ">"))?;
         },
         Type::OptionBool | Type::OptionUsize => quote! {
-            if let Some(ref ele) = self.#name {
+            if let Some(ref value) = self.#name {
                 write!(&mut writer, concat!("<" , #tag, ">"))?;
-                write!(&mut writer, "{}", strong_xml::utils::xml_escape(&self.#name.to_string()))?;
+                write!(&mut writer, "{}", strong_xml::utils::xml_escape(&value.to_string()))?;
                 write!(&mut writer, concat!("</" , #tag, ">"))?;
             }
         },

--- a/test-suite/tests/text.rs
+++ b/test-suite/tests/text.rs
@@ -8,6 +8,20 @@ struct Root<'a> {
     content: Cow<'a, str>,
 }
 
+#[derive(XmlWrite, PartialEq, Debug)] // XmlRead
+#[xml(tag = "root")]
+struct TypedRoot {
+    #[xml(text)]
+    id: usize,
+}
+
+#[derive(XmlWrite, PartialEq, Debug)] // XmlRead
+#[xml(tag = "root")]
+struct Test {
+    #[xml(flatten_text = "my:confirm")]
+    confirm: bool,
+}
+
 #[test]
 fn test() -> XmlResult<()> {
     let _ = env_logger::builder()
@@ -28,6 +42,24 @@ fn test() -> XmlResult<()> {
         },
         Root::from_str(r#"<root>content</root>"#)?
     );
+
+    assert_eq!(
+        r#"<root>42</root>"#,
+        TypedRoot { id: 42 }.to_string().unwrap()
+    );
+    // assert_eq!(
+    //     TypedRoot { id: 42 },
+    //     TypedRoot::from_str(r#"<root>42</root>"#)?
+    // );
+
+    assert_eq!(
+        r#"<root><my:confirm>true</my:confirm></root>"#,
+        Test { confirm: true }.to_string().unwrap()
+    );
+    // assert_eq!(
+    //     Test { confirm: true },
+    //     Test::from_str(r#"<root><my:confirm>true</my:confirm></root>"#)?
+    // );
 
     Ok(())
 }


### PR DESCRIPTION
`#[xml(text)]` and `#[xml(flatten_text)]` are now able to accept types like `bool`, `Option<bool>`, `usize` and `Option<usize>`. But I'm not sure how XmlRead will be able to accept them...