### PR TITLE
implement std::error::Error for XmlError

### DIFF
--- a/strong-xml/src/xml_error.rs
+++ b/strong-xml/src/xml_error.rs
@@ -42,7 +42,18 @@ impl From<ParserError> for XmlError {
 /// Specialized `Result` which the error value is `Error`.
 pub type XmlResult<T> = Result<T, XmlError>;
 
-impl Error for XmlError {}
+impl Error for XmlError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use XmlError::*;
+        match self {
+            IO(e) => Some(e),
+            Parser(e) => Some(e),
+            Utf8(e) => Some(e),
+            FromStr(e) => Some(e.as_ref()),
+            _ => None,
+        }
+    }
+}
 
 impl std::fmt::Display for XmlError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/strong-xml/src/xml_error.rs
+++ b/strong-xml/src/xml_error.rs
@@ -12,7 +12,7 @@ pub enum XmlError {
     MissingField { name: String, field: String },
     UnterminatedEntity { entity: String },
     UnrecognizedSymbol { symbol: String },
-    FromStr(Box<dyn Error>),
+    FromStr(Box<dyn Error + Send + Sync>),
 }
 
 impl From<IOError> for XmlError {
@@ -41,3 +41,29 @@ impl From<ParserError> for XmlError {
 
 /// Specialized `Result` which the error value is `Error`.
 pub type XmlResult<T> = Result<T, XmlError>;
+
+impl Error for XmlError {}
+
+impl std::fmt::Display for XmlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use XmlError::*;
+        match self {
+            IO(e) => write!(f, "I/O error: {}", e),
+            Parser(e) => write!(f, "XML parser error: {}", e),
+            Utf8(e) => write!(f, "invalid UTF-8: {}", e),
+            UnexpectedEof => f.write_str("unexpected end of file"),
+            UnexpectedToken { token } => write!(f, "unexpected token in XML: {:?}", token),
+            TagMismatch { expected, found } => write!(
+                f,
+                "mismatched XML tag; expected {:?}, found {:?}",
+                expected, found
+            ),
+            MissingField { name, field } => {
+                write!(f, "missing field in XML of {:?}: {:?}", name, field)
+            }
+            UnterminatedEntity { entity } => write!(f, "unrecognized XML entity: {}", entity),
+            UnrecognizedSymbol { symbol } => write!(f, "unrecognized XML symbol: {}", symbol),
+            FromStr(e) => write!(f, "error parsing XML value: {}", e),
+        }
+    }
+}

--- a/strong-xml/src/xml_error.rs
+++ b/strong-xml/src/xml_error.rs
@@ -72,7 +72,7 @@ impl std::fmt::Display for XmlError {
             MissingField { name, field } => {
                 write!(f, "missing field in XML of {:?}: {:?}", name, field)
             }
-            UnterminatedEntity { entity } => write!(f, "unrecognized XML entity: {}", entity),
+            UnterminatedEntity { entity } => write!(f, "unterminated XML entity: {}", entity),
             UnrecognizedSymbol { symbol } => write!(f, "unrecognized XML symbol: {}", symbol),
             FromStr(e) => write!(f, "error parsing XML value: {}", e),
         }

--- a/test-suite/tests/where_clause.rs
+++ b/test-suite/tests/where_clause.rs
@@ -12,7 +12,7 @@ where
     U: Display + FromStr,
     // This bounds is required because we need to wrap
     // the error with a `Box<dyn Error>`
-    <U as FromStr>::Err: 'static + Error,
+    <U as FromStr>::Err: 'static + Error + Send + Sync,
 {
     #[xml(attr = "attr")]
     attr: U,


### PR DESCRIPTION
This makes it possible to use this type with crates like `anyhow`.

Also require that XmlError::FromStr internal error be Send + Sync. ~This
is a breaking change (adding extra bounds to a public type) so requires
a version bump.~