### PR TITLE
accept CDATA anywhere text would be accepted

### DIFF
--- a/strong-xml-derive/src/read/named.rs
+++ b/strong-xml-derive/src/read/named.rs
@@ -65,9 +65,8 @@ pub fn read(tag: &LitStr, ele_name: TokenStream, fields: &[Field]) -> TokenStrea
             ty,
             tag,
             name,
-            is_cdata,
             ..
-        } => Some(read_flatten_text(tag, bind, name, ty, &ele_name, *is_cdata)),
+        } => Some(read_flatten_text(tag, bind, name, ty, &ele_name,)),
         _ => None,
     });
 
@@ -76,9 +75,8 @@ pub fn read(tag: &LitStr, ele_name: TokenStream, fields: &[Field]) -> TokenStrea
             bind,
             ty,
             name,
-            is_cdata,
             ..
-        } => Some(read_text(&tag, bind, name, ty, &ele_name, *is_cdata)),
+        } => Some(read_text(&tag, bind, name, ty, &ele_name)),
         _ => None,
     });
 
@@ -203,7 +201,6 @@ fn read_text(
     name: &TokenStream,
     ty: &Type,
     ele_name: &TokenStream,
-    is_cdata: bool,
 ) -> TokenStream {
     let from_str = from_str(ty);
 
@@ -213,7 +210,7 @@ fn read_text(
         quote! {
             strong_xml::log_start_reading_field!(#ele_name, #name);
 
-            let __value = reader.read_text(#tag, #is_cdata)?;
+            let __value = reader.read_text(#tag)?;
             #bind = Some(#from_str);
 
             strong_xml::log_finish_reading_field!(#ele_name, #name);
@@ -255,18 +252,17 @@ fn read_flatten_text(
     name: &TokenStream,
     ty: &Type,
     ele_name: &TokenStream,
-    is_cdata: bool,
 ) -> TokenStream {
     let from_str = from_str(ty);
 
     let read_text = if ty.is_vec() {
         quote! {
-            let __value = reader.read_text(#tag, #is_cdata)?;
+            let __value = reader.read_text(#tag)?;
             #bind.push(#from_str);
         }
     } else {
         quote! {
-            let __value = reader.read_text(#tag, #is_cdata)?;
+            let __value = reader.read_text(#tag)?;
             #bind = Some(#from_str);
         }
     };

--- a/strong-xml-derive/src/read/named.rs
+++ b/strong-xml-derive/src/read/named.rs
@@ -66,17 +66,12 @@ pub fn read(tag: &LitStr, ele_name: TokenStream, fields: &[Field]) -> TokenStrea
             tag,
             name,
             ..
-        } => Some(read_flatten_text(tag, bind, name, ty, &ele_name,)),
+        } => Some(read_flatten_text(tag, bind, name, ty, &ele_name)),
         _ => None,
     });
 
     let read_text_fields = fields.iter().filter_map(|field| match field {
-        Field::Text {
-            bind,
-            ty,
-            name,
-            ..
-        } => Some(read_text(&tag, bind, name, ty, &ele_name)),
+        Field::Text { bind, ty, name, .. } => Some(read_text(&tag, bind, name, ty, &ele_name)),
         _ => None,
     });
 

--- a/strong-xml/src/xml_reader.rs
+++ b/strong-xml/src/xml_reader.rs
@@ -46,8 +46,11 @@ impl<'a> XmlReader<'a> {
                     ..
                 }
                 | Token::Attribute { .. } => (),
-                Token::Text { text } | Token::Cdata { text, .. } => {
+                Token::Text { text } => {
                     res = Some(xml_unescape(text.as_str())?);
+                }
+                Token::Cdata { text, .. } => {
+                    res = Some(Cow::Borrowed(text.as_str()));
                 }
                 Token::ElementEnd {
                     end: ElementEnd::Close(_, _),

--- a/strong-xml/src/xml_reader.rs
+++ b/strong-xml/src/xml_reader.rs
@@ -258,19 +258,24 @@ fn read_text() -> XmlResult<()> {
     let mut reader = XmlReader::new("<parent></parent>");
 
     assert!(reader.next().is_some()); // "<parent"
-    assert_eq!(reader.read_text("parent", false)?, "");
+    assert_eq!(reader.read_text("parent")?, "");
     assert!(reader.next().is_none());
 
     reader = XmlReader::new("<parent>text</parent>");
 
     assert!(reader.next().is_some()); // "<parent"
-    assert_eq!(reader.read_text("parent", false)?, "text");
+    assert_eq!(reader.read_text("parent")?, "text");
     assert!(reader.next().is_none());
 
     reader = XmlReader::new("<parent attr=\"value\">text</parent>");
 
     assert!(reader.next().is_some()); // "<parent"
-    assert_eq!(reader.read_text("parent", false)?, "text");
+    assert_eq!(reader.read_text("parent")?, "text");
+    assert!(reader.next().is_none());
+
+    reader = XmlReader::new("<parent attr=\"value\">this &amp; that</parent>");
+    assert!(reader.next().is_some());
+    assert_eq!(reader.read_text("parent")?, "this & that");
     assert!(reader.next().is_none());
 
     Ok(())
@@ -281,19 +286,24 @@ fn read_cdata_text() -> XmlResult<()> {
     let mut reader = XmlReader::new("<parent><![CDATA[]]></parent>");
 
     assert!(reader.next().is_some()); // "<parent"
-    assert_eq!(reader.read_text("parent", true)?, "");
+    assert_eq!(reader.read_text("parent")?, "");
     assert!(reader.next().is_none());
 
     reader = XmlReader::new("<parent><![CDATA[text]]></parent>");
 
     assert!(reader.next().is_some()); // "<parent"
-    assert_eq!(reader.read_text("parent", true)?, "text");
+    assert_eq!(reader.read_text("parent")?, "text");
     assert!(reader.next().is_none());
 
     reader = XmlReader::new("<parent attr=\"value\"><![CDATA[text]]></parent>");
 
     assert!(reader.next().is_some()); // "<parent"
-    assert_eq!(reader.read_text("parent", true)?, "text");
+    assert_eq!(reader.read_text("parent")?, "text");
+    assert!(reader.next().is_none());
+
+    reader = XmlReader::new("<parent attr=\"value\"><![CDATA[this &amp; <that/>]]></parent>");
+    assert!(reader.next().is_some());
+    assert_eq!(reader.read_text("parent")?, "this &amp; <that/>");
     assert!(reader.next().is_none());
 
     Ok(())

--- a/strong-xml/src/xml_reader.rs
+++ b/strong-xml/src/xml_reader.rs
@@ -36,7 +36,7 @@ impl<'a> XmlReader<'a> {
     }
 
     #[inline]
-    pub fn read_text(&mut self, end_tag: &str, is_cdata: bool) -> XmlResult<Cow<'a, str>> {
+    pub fn read_text(&mut self, end_tag: &str) -> XmlResult<Cow<'a, str>> {
         let mut res = None;
 
         while let Some(token) = self.next() {
@@ -46,10 +46,7 @@ impl<'a> XmlReader<'a> {
                     ..
                 }
                 | Token::Attribute { .. } => (),
-                Token::Text { text } if !is_cdata => {
-                    res = Some(xml_unescape(text.as_str())?);
-                }
-                Token::Cdata { text, .. } if is_cdata => {
+                Token::Text { text } | Token::Cdata { text, .. } => {
                     res = Some(xml_unescape(text.as_str())?);
                 }
                 Token::ElementEnd {


### PR DESCRIPTION
Fixes #17

CDATA is semantically the same as text, and should be read anywhere text would be read.

Additionally, CDATA is raw text and must not be unescaped.