### PR TITLE
release: bump version to 0.6.1

### DIFF
--- a/strong-xml-derive/Cargo.toml
+++ b/strong-xml-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strong-xml-derive"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/PoiScript/strong-xml"
 description = "Derive marco of strong-xml."
 license = "MIT"

--- a/strong-xml/Cargo.toml
+++ b/strong-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strong-xml"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/PoiScript/strong-xml"
 description = "Strong typed xml, based on xmlparser."
 license = "MIT"
@@ -14,7 +14,7 @@ jetscii = "0.4.4"
 lazy_static = "1.4.0"
 log = { version = "0.4.8", optional = true }
 memchr = "2.3.3"
-strong-xml-derive = { version = "0.6.0", path = "../strong-xml-derive" }
+strong-xml-derive = { version = "0.6.1", path = "../strong-xml-derive" }
 xmlparser = "0.13.1"
 
 [dev-dependencies]

--- a/strong-xml/README.md
+++ b/strong-xml/README.md
@@ -9,7 +9,7 @@ Strong typed xml, based on xmlparser.
 ### Quick Start
 
 ```toml
-strong-xml = "0.6.0"
+strong-xml = "0.6.1"
 ```
 
 ```rust


### PR DESCRIPTION
It looks like I can't make my text/cdata handling work well with 0.6.0 (getting those nasty unexpected token errors)

Do you mind publishing 0.6.1 to crates.io?

(I prepared the PR with necessary changes)