### PR TITLE
Update to jetscii 0.5

### DIFF
--- a/strong-xml/Cargo.toml
+++ b/strong-xml/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["xml", "xmlparser", "derive", "proc-macro"]
 edition = "2018"
 
 [dependencies]
-jetscii = "0.4"
+jetscii = "0.5"
 lazy_static = "1.4"
 log = { version = "0.4", optional = true }
 memchr = "2.3"


### PR DESCRIPTION
This PR fixes an issue with cargo-expand and the dependency jetscii v0.4 

```
strong-xml-issue on master [?]
$ cargo expand
    Updating crates.io index
    Checking jetscii v0.4.4
error: generic parameters may not be used in const operations
   --> /.cargo/registry/src/github.com-1ecc6299db9ec823/jetscii-0.4.4/src/simd.rs:109:13
    |
109 |             T::CONTROL_BYTE,
    |             ^^^^^^^^^^^^^^^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
error: generic parameters may not be used in const operations
   --> /.cargo/registry/src/github.com-1ecc6299db9ec823/jetscii-0.4.4/src/simd.rs:148:13
    |
148 |             T::CONTROL_BYTE,
    |             ^^^^^^^^^^^^^^^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
```