### PR TITLE
implicit container tags

### DIFF
--- a/strong-xml-derive/src/read/named.rs
+++ b/strong-xml-derive/src/read/named.rs
@@ -225,6 +225,11 @@ fn read_children(
             #bind.push(<#ty as strong_xml::XmlRead>::from_reader(reader)?);
         },
         Type::OptionT(ty) | Type::T(ty) => quote! {
+            if #bind.is_some() {
+                return Err(XmlError::DuplicateField {
+                    field: stringify!(#( #tags )|*).to_owned(),
+                });
+            }
             #bind = Some(<#ty as strong_xml::XmlRead>::from_reader(reader)?);
         },
         _ => panic!("`child` attribute only supports Vec<T>, Option<T> and T."),
@@ -257,6 +262,11 @@ fn read_flatten_text(
         }
     } else {
         quote! {
+            if #bind.is_some() {
+                return Err(XmlError::DuplicateField {
+                    field: #tag.to_owned(),
+                });
+            }
             let __value = reader.read_text(#tag)?;
             #bind = Some(#from_str);
         }

--- a/strong-xml/README.md
+++ b/strong-xml/README.md
@@ -293,6 +293,21 @@ assert_eq!(
 );
 ```
 
+#### `#[xml(container)]`
+
+`flatten_text` and `child` can be embedded in a container tag.
+
+```rust
+#[derive(XmlRead, Debug, Clone)]
+#[xml(tag = "root")]
+struct Root {
+    #[xml(container = "cont", flatten_text = "sub", default)]
+    sub_values: Vec<u64>,
+}
+```
+
+This will parse `<root><cont><sub>1</sub><sub>2</sub><sub>3</sub></cont></root>`.
+
 ### License
 
 MIT

--- a/strong-xml/src/xml_error.rs
+++ b/strong-xml/src/xml_error.rs
@@ -12,6 +12,7 @@ pub enum XmlError {
     MissingField { name: String, field: String },
     UnterminatedEntity { entity: String },
     UnrecognizedSymbol { symbol: String },
+    DuplicateField { field: String },
     FromStr(Box<dyn Error + Send + Sync>),
 }
 
@@ -74,6 +75,7 @@ impl std::fmt::Display for XmlError {
             }
             UnterminatedEntity { entity } => write!(f, "unterminated XML entity: {}", entity),
             UnrecognizedSymbol { symbol } => write!(f, "unrecognized XML symbol: {}", symbol),
+            DuplicateField { field } => write!(f, "unexpected duplicate field: {}", field),
             FromStr(e) => write!(f, "error parsing XML value: {}", e),
         }
     }

--- a/test-suite/tests/containers.rs
+++ b/test-suite/tests/containers.rs
@@ -1,0 +1,160 @@
+use std::borrow::Cow;
+use strong_xml::{XmlRead, XmlResult, XmlWrite};
+
+#[derive(XmlWrite, XmlRead, PartialEq, Debug)]
+#[xml(tag = "tag1")]
+struct Tag1<'a> {
+    #[xml(attr = "att1")]
+    att1: Option<Cow<'a, str>>,
+    #[xml(text)]
+    content: Cow<'a, str>,
+}
+
+#[derive(XmlWrite, XmlRead, PartialEq, Debug)]
+#[xml(tag = "tag2")]
+struct Tag2<'a> {
+    #[xml(child = "tag1", container = "container", default)]
+    tag1: Vec<Tag1<'a>>,
+}
+
+#[derive(XmlWrite, XmlRead, PartialEq, Debug)]
+#[xml(tag = "tag2")]
+struct Tag2Opt<'a> {
+    #[xml(child = "tag1", container = "container")]
+    tag1: Option<Vec<Tag1<'a>>>,
+}
+
+#[derive(XmlWrite, XmlRead, PartialEq, Debug)]
+#[xml(tag = "tag3")]
+struct Tag3 {
+    #[xml(flatten_text = "value", container = "container", default)]
+    data: Vec<u64>,
+}
+
+#[derive(XmlWrite, XmlRead, PartialEq, Debug)]
+#[xml(tag = "tag3")]
+struct Tag3Opt {
+    #[xml(flatten_text = "value", container = "container")]
+    data: Option<Vec<u64>>,
+}
+
+#[test]
+fn test() -> XmlResult<()> {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .format_timestamp(None)
+        .try_init();
+
+    assert_eq!(
+        Tag2::from_str(
+            r#"<tag2><container><tag1 att1="att1">foo</tag1><tag1>bar</tag1></container></tag2>"#
+        )?,
+        Tag2 {
+            tag1: vec![
+                Tag1 {
+                    att1: Some("att1".into()),
+                    content: "foo".into(),
+                },
+                Tag1 {
+                    att1: None,
+                    content: "bar".into(),
+                }
+            ],
+        }
+    );
+
+    assert_eq!(
+        Tag3::from_str(
+            r#"<tag3><container><value>123</value><value>0</value></container></tag3>"#
+        )?,
+        Tag3 { data: vec![123, 0] }
+    );
+
+    assert_eq!(
+        Tag2 {
+            tag1: vec![
+                Tag1 {
+                    att1: Some("att1".into()),
+                    content: "foo".into(),
+                },
+                Tag1 {
+                    att1: None,
+                    content: "bar".into(),
+                }
+            ],
+        }
+        .to_string()?,
+        r#"<tag2><container><tag1 att1="att1">foo</tag1><tag1>bar</tag1></container></tag2>"#,
+    );
+
+    assert_eq!(
+        Tag3 { data: vec![123, 0] }.to_string()?,
+        r#"<tag3><container><value>123</value><value>0</value></container></tag3>"#,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_empty() -> XmlResult<()> {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .format_timestamp(None)
+        .try_init();
+
+    assert_eq!(Tag2::from_str(r#"<tag2></tag2>"#)?, Tag2 { tag1: vec![] });
+
+    assert_eq!(
+        Tag2::from_str(r#"<tag2><container></container></tag2>"#)?,
+        Tag2 { tag1: vec![] }
+    );
+
+    assert_eq!(
+        Tag2::from_str(r#"<tag2><container><unknown/></container></tag2>"#)?,
+        Tag2 { tag1: vec![] }
+    );
+
+    assert_eq!(
+        Tag2Opt::from_str(r#"<tag2></tag2>"#)?,
+        Tag2Opt { tag1: None }
+    );
+
+    assert_eq!(
+        Tag2Opt::from_str(r#"<tag2><container></container></tag2>"#)?,
+        Tag2Opt { tag1: Some(vec![]) }
+    );
+
+    assert_eq!(
+        Tag2Opt::from_str(r#"<tag2><container><unknown/></container></tag2>"#)?,
+        Tag2Opt { tag1: Some(vec![]) }
+    );
+
+    assert_eq!(Tag3::from_str(r#"<tag3></tag3>"#)?, Tag3 { data: vec![] });
+
+    assert_eq!(
+        Tag3::from_str(r#"<tag3><container></container></tag3>"#)?,
+        Tag3 { data: vec![] }
+    );
+
+    assert_eq!(
+        Tag3::from_str(r#"<tag3><container><unknown/></container></tag3>"#)?,
+        Tag3 { data: vec![] }
+    );
+
+    assert_eq!(
+        Tag3Opt::from_str(r#"<tag3></tag3>"#)?,
+        Tag3Opt { data: None }
+    );
+
+    assert_eq!(
+        Tag3Opt::from_str(r#"<tag3><container></container></tag3>"#)?,
+        Tag3Opt { data: Some(vec![]) }
+    );
+
+    assert_eq!(
+        Tag3Opt::from_str(r#"<tag3><container><unknown/></container></tag3>"#)?,
+        Tag3Opt { data: Some(vec![]) }
+    );
+
+    Ok(())
+}

--- a/test-suite/tests/struct.rs
+++ b/test-suite/tests/struct.rs
@@ -92,3 +92,23 @@ fn test() -> XmlResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_duplicate() -> XmlResult<()> {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .format_timestamp(None)
+        .try_init();
+
+    assert!(Tag3::from_str(
+        r#"<tag3 att1="att1"><text>content1</text><text>content2</text></tag3>"#
+    )
+    .is_err());
+
+    assert!(Tag3::from_str(
+        r#"<tag3 att1="att1"><tag2>content1</tag2><tag2>content2</tag2></tag3>"#
+    )
+    .is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
Decided to move the #[xml()] attribute conflict handling to after the parsing because it seemed me that it makes more sense there but in the end it doesn't make a lot of difference. I will move it back if you prefer.

I added a commit that introduces checking for duplicate tags when parsing non-vec fields - let me know if you want me to split it into a separate PR.