### PR TITLE
Treat empty tags equivalently to immediately closed tags.

### DIFF
--- a/strong-xml/src/xml_reader.rs
+++ b/strong-xml/src/xml_reader.rs
@@ -67,6 +67,12 @@ impl<'a> XmlReader<'a> {
                         });
                     }
                 }
+                Token::ElementEnd {
+                    end: ElementEnd::Empty,
+                    ..
+                } => {
+                    break;
+                }
                 token => {
                     return Err(XmlError::UnexpectedToken {
                         token: format!("{:?}", token),

--- a/test-suite/tests/string_empty_tag.rs
+++ b/test-suite/tests/string_empty_tag.rs
@@ -1,0 +1,33 @@
+use strong_xml::{XmlRead, XmlResult, XmlWrite};
+
+#[derive(Debug, PartialEq, XmlRead, XmlWrite)]
+#[xml(tag = "head")]
+struct Head {
+    #[xml(flatten_text = "title")]
+    title: String,
+}
+
+#[test]
+fn test() -> XmlResult<()> {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .format_timestamp(None)
+        .try_init();
+
+    assert_eq!(
+        Head::from_str(r#"<head><title/></head>"#)?,
+        Head {
+            title: "".into(),
+        }
+    );
+
+    assert_eq!(
+        Head {
+            title: "".into(),
+        }
+        .to_string()?,
+        r#"<head><title></title></head>"#
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes https://github.com/PoiScript/strong-xml/issues/35